### PR TITLE
Fix %i[] for JRuby

### DIFF
--- a/lib/vk-ruby/params.rb
+++ b/lib/vk-ruby/params.rb
@@ -38,7 +38,7 @@ class VK::Params < Struct.new(:config, :options)
   alias stack middlewares
 
   def query
-    %i[host verb timeout open_timeout ssl proxy middlewares stack].inject(options.dup) do |result, name|
+    %w(host verb timeout open_timeout ssl proxy middlewares stack).map(&:to_sym).inject(options.dup) do |result, name|
       result.delete(name)
       result
     end


### PR DESCRIPTION
Jruby 1.7.9, 1.7.19 raises exception on:
```
SyntaxError: /Users/nyaa/.rvm/gems/jruby-1.7.9@onlinetours/gems/vk-ruby-1.0.2/lib/vk-ruby/params.rb:41: unknown type of %string
    %i[host verb timeout open_timeout ssl proxy middlewares stack].inject(options.dup) do |result, name|
      ^
          require at org/jruby/RubyKernel.java:1083
          require at /Users/nyaa/.rvm/gems/jruby-1.7.9@onlinetours/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:247
  load_dependency at /Users/nyaa/.rvm/gems/jruby-1.7.9@onlinetours/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:232
          require at /Users/nyaa/.rvm/gems/jruby-1.7.9@onlinetours/gems/activesupport-4.1.8/lib/active_support/dependencies.rb:247
           (root) at /Users/nyaa/.rvm/gems/jruby-1.7.9@onlinetours/gems/vk-ruby-1.0.2/lib/vk-ruby.rb:1
          require at org/jruby/RubyKernel.java:1083
           (root) at /Users/nyaa/.rvm/gems/jruby-1.7.9@onlinetours/gems/vk-ruby-1.0.2/lib/vk-ruby.rb:23
             each at org/jruby/RubyArray.java:1613
           (root) at /Users/nyaa/.rvm/gems/jruby-1.7.9@global/gems/bundler-1.7.8/lib/bundler/runtime.rb:1
             each at org/jruby/RubyArray.java:1613
          require at /Users/nyaa/.rvm/gems/jruby-1.7.9@global/gems/bundler-1.7.8/lib/bundler/runtime.rb:76
          require at /Users/nyaa/.rvm/gems/jruby-1.7.9@global/gems/bundler-1.7.8/lib/bundler/runtime.rb:72
          require at /Users/nyaa/.rvm/gems/jruby-1.7.9@global/gems/bundler-1.7.8/lib/bundler/runtime.rb:61
          require at org/jruby/RubyKernel.java:1083
          require at /Users/nyaa/.rvm/gems/jruby-1.7.9@global/gems/bundler-1.7.8/lib/bundler.rb:134
           (root) at /Users/nyaa/github/onlinetours/config/application.rb:6
           (root) at /Users/nyaa/.rvm/gems/jruby-1.7.9@onlinetours/gems/sidekiq-3.3.0/lib/sidekiq/cli.rb:1
             load at org/jruby/RubyKernel.java:1099
      boot_system at /Users/nyaa/.rvm/gems/jruby-1.7.9@onlinetours/gems/sidekiq-3.3.0/lib/sidekiq/cli.rb:231
             eval at org/jruby/RubyKernel.java:1119
           (root) at /Users/nyaa/.rvm/gems/jruby-1.7.9@onlinetours/bin/jruby_executable_hooks:15
```

This PR fixes it - create string array and map it to symbols array